### PR TITLE
Add UML diagram generation

### DIFF
--- a/doc/example_flow.plantuml
+++ b/doc/example_flow.plantuml
@@ -1,0 +1,23 @@
+@startuml
+participant Initiator
+participant Acceptor
+participant Notary
+title ExampleFlow 1\n(IOU)
+
+autonumber
+
+note over Initiator : Generating transaction based on new IOU
+note over Initiator : Verifying contract constraints.
+note over Initiator : Signing transaction with private key
+Initiator -> Acceptor : Sending proposed transaction to recipient for review
+note over Acceptor : Receiving proposed transaction from sender
+note over Acceptor : Verifying signatures and contract constraints
+note over Acceptor : Signing proposed transaction with our private key
+Acceptor -> Notary : Requesting signature by notary service
+note over Notary : Sign transaction
+Acceptor <- Notary: Receive signed transaction
+...
+note over Acceptor : Record transaction
+Initiator <- Acceptor : Broadcasting transaction to participants
+note over Initiator : Record transaction
+@enduml

--- a/java-source/build.gradle
+++ b/java-source/build.gradle
@@ -45,6 +45,9 @@ dependencies {
         exclude group: "bouncycastle"
     }
 
+    // PlantUML: For Generation of Sequence Diagrams of the Flows
+    compile 'net.sourceforge.plantuml:plantuml:8039'
+
     // CorDapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps
 }
@@ -116,6 +119,17 @@ publishing {
             artifact javadocJar
         }
     }
+}
+
+task generateFlowDiagram(type: JavaExec) {
+    classpath = files("build/jythonDeps/plantuml-8039.jar")
+    main = "net.sourceforge.plantuml.Run"
+    args = [
+            "-tsvg",
+            "-output", "../java-source/build/doc",
+            "-exclude", "inc_*",
+            "../doc/*.plantuml"
+    ]
 }
 
 task runExampleClientRPC(type: JavaExec) {

--- a/kotlin-source/build.gradle
+++ b/kotlin-source/build.gradle
@@ -45,6 +45,9 @@ dependencies {
         exclude group: "bouncycastle"
     }
 
+    // PlantUML: For Generation of Sequence Diagrams of the Flows
+    compile 'net.sourceforge.plantuml:plantuml:8039'
+
     // CorDapp dependencies
     // Specify your cordapp's dependencies below, including dependent cordapps
 }
@@ -116,6 +119,17 @@ publishing {
             artifact javadocJar
         }
     }
+}
+
+task generateFlowDiagram(type: JavaExec) {
+    classpath = files("build/jythonDeps/plantuml-8039.jar")
+    main = "net.sourceforge.plantuml.Run"
+    args = [
+            "-tsvg",
+            "-output", "../kotlin-source/build/doc",
+            "-exclude", "inc_*",
+            "../doc/*.plantuml"
+    ]
 }
 
 task runExampleClientRPC(type: JavaExec) {


### PR DESCRIPTION
Sometimes it is difficult to immediately understand how the flow works merely by looking at the code. 

This commit makes it possible to document this using a `plantuml` file, which can then be used to generate a UML based sequence diagram using the Gradle task`.

```
./gradlew generateFlowDiagram
```
An SVG file will be created in the `build/doc` directory for the Java and Kotlin sources.

![Example Flow](http://i.imgur.com/yvLnafn.png)

The library used for this is the open source tool [PlantUML](http://plantuml.com/sequence-diagram).

**Note:**
* The step `Validating response from Notary service` is not done in code.
---
This contribution is in compliance with the terms of 
https://github.com/corda/corda/blob/master/CONTRIBUTING.md