### PR TITLE
Renames of rpcAPI call

### DIFF
--- a/java-source/src/main/java/com/example/api/ExampleApi.java
+++ b/java-source/src/main/java/com/example/api/ExampleApi.java
@@ -59,7 +59,7 @@ public class ExampleApi {
     @Path("peers")
     @Produces(MediaType.APPLICATION_JSON)
     public Map<String, List<X500Name>> getPeers() {
-        DataFeed<List<NodeInfo>, NetworkMapCache.MapChange> nodeInfo = services.networkMapUpdates();
+        DataFeed<List<NodeInfo>, NetworkMapCache.MapChange> nodeInfo = services.networkMapFeed();
         notUsed(nodeInfo.getUpdates());
         return ImmutableMap.of(
                 "peers",

--- a/kotlin-source/src/main/kotlin/com/example/api/ExampleApi.kt
+++ b/kotlin-source/src/main/kotlin/com/example/api/ExampleApi.kt
@@ -42,7 +42,7 @@ class ExampleApi(val services: CordaRPCOps) {
     @Path("peers")
     @Produces(MediaType.APPLICATION_JSON)
     fun getPeers(): Map<String, List<X500Name>> {
-        val (nodeInfo, nodeUpdates) = services.networkMapUpdates()
+        val (nodeInfo, nodeUpdates) = services.networkMapFeed()
         nodeUpdates.notUsed()
         return mapOf("peers" to nodeInfo
                 .map { it.legalIdentity.name }


### PR DESCRIPTION
Changes made to make the tutorial build and run, as well as pass unit testing.

*Renames the following to compile and run tests- `networkMapUpdates()` to `networkMapFeed()`
*Discussed in [PR #76](https://github.com/corda/cordapp-tutorial/pull/76#issuecomment-319956092)