### PR TITLE
Fix example rpc client ports

### DIFF
--- a/java-source/build.gradle
+++ b/java-source/build.gradle
@@ -113,5 +113,5 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
 task runExampleClientRPCJava(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'com.example.client.ExampleClientRPC'
-    args 'localhost:10006'
+    args 'localhost:10008'
 }

--- a/kotlin-source/build.gradle
+++ b/kotlin-source/build.gradle
@@ -120,5 +120,5 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
 task runExampleClientRPCKotlin(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'com.example.client.ExampleClientRPCKt'
-    args 'localhost:10006'
+    args 'localhost:10008'
 }


### PR DESCRIPTION
The RPC example client now connects to the Notaries p2p port instead of Party A's rpc port after the recent port number changes, which causes an error.