### PR TITLE
corrected the sendMessage calling via lamda exp

### DIFF
--- a/java-source/src/main/java/com/example/flow/ExampleFlow.java
+++ b/java-source/src/main/java/com/example/flow/ExampleFlow.java
@@ -23,7 +23,14 @@ public class ExampleFlow {
         public Void call() throws FlowException {
             FlowSession otherPartySession = initiateFlow(otherParty);
             List<FlowSession> sessions = ImmutableList.of(otherPartySession);
-            sessions.forEach( it -> sendAMessage(it, new Triple("a", "b", "c")));
+           // sessions.forEach( it -> sendAMessage(it, new Triple("a", "b", "c")));
+            /**
+             * please find the link for more info:
+             * https://stackoverflow.com/questions/50638968/in-corda-unexpected-task-state-when-running-a-flow?rq=1
+             */
+            for(FlowSession session : sessions){
+                sendAMessage(session, new Triple("a", "b", "c"));
+            }
             return null;
         }
     }


### PR DESCRIPTION
I have run the unit test case.

I removed the calling of the sendMessage via lamda expression to the 'for each loop' .

 “I hereby certify that my contribution is in accordance with the Developer Certificate of Origin (https://github.com/corda/corda/blob/master/CONTRIBUTING.md#developer-certificate-of-origin).”