### PR TITLE
Change Hibernate field mapping type for UUID, database migration scripts.

### DIFF
--- a/java-source/src/main/java/com/example/schema/IOUSchemaV1.java
+++ b/java-source/src/main/java/com/example/schema/IOUSchemaV1.java
@@ -3,6 +3,7 @@ package com.example.schema;
 import com.google.common.collect.ImmutableList;
 import net.corda.core.schemas.MappedSchema;
 import net.corda.core.schemas.PersistentState;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -23,7 +24,7 @@ public class IOUSchemaV1 extends MappedSchema {
         @Column(name = "lender") private final String lender;
         @Column(name = "borrower") private final String borrower;
         @Column(name = "value") private final int value;
-        @Column(name = "linear_id") private final UUID linearId;
+        @Column(name = "linear_id") @Type(type = "uuid-char") private final UUID linearId;
 
 
         public PersistentIOU(String lender, String borrower, int value, UUID linearId) {

--- a/java-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
+++ b/java-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
@@ -10,8 +10,8 @@
             <column name="transaction_id" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
-            <column name="lender" type="NVARCHAR"/>
-            <column name="borrower" type="NVARCHAR"/>
+            <column name="lender" type="NVARCHAR(255)"/>
+            <column name="borrower" type="NVARCHAR(255)"/>
             <column name="value" type="INT"/>
             <column name="linear_id" type="VARCHAR(255)"/>
         </createTable>

--- a/java-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
+++ b/java-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
@@ -1,0 +1,29 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd" >
+    <changeSet author="R3.Corda" id="i-o-u-schema-v1-create-table">
+        <createTable tableName="iou_states">
+            <column name="output_index" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="transaction_id" type="NVARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="lender" type="NVARCHAR"/>
+            <column name="borrower" type="NVARCHAR"/>
+            <column name="value" type="INT"/>
+            <column name="linear_id" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="i-o-u-schema-v1-add-pk">
+        <addPrimaryKey columnNames="output_index, transaction_id" constraintName="iou_states_pkey" tableName="iou_states"/>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="i-o-u-schema-v1-non-clustered-pk" onValidationFail="MARK_RAN">
+        <dropPrimaryKey tableName="iou_states" constraintName="iou_states_pkey"/>
+        <addPrimaryKey tableName="iou_states" columnNames="output_index, transaction_id"
+                       constraintName="iou_states_pkey" clustered="false"/>
+    </changeSet>
+</databaseChangeLog>

--- a/java-source/src/main/resources/migration/i-o-u-schema-v1.changelog-master.xml
+++ b/java-source/src/main/resources/migration/i-o-u-schema-v1.changelog-master.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd" >
+
+    <include file="migration/i-o-u-schema-v1.changelog-init.xml"/>
+
+</databaseChangeLog>

--- a/kotlin-source/src/main/kotlin/com/example/schema/IOUSchema.kt
+++ b/kotlin-source/src/main/kotlin/com/example/schema/IOUSchema.kt
@@ -2,6 +2,7 @@ package com.example.schema
 
 import net.corda.core.schemas.MappedSchema
 import net.corda.core.schemas.PersistentState
+import org.hibernate.annotations.Type
 import java.util.*
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -32,6 +33,7 @@ object IOUSchemaV1 : MappedSchema(
             var value: Int,
 
             @Column(name = "linear_id")
+            @Type(type = "uuid-char")
             var linearId: UUID
     ) : PersistentState() {
         // Default constructor required by hibernate.

--- a/kotlin-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
+++ b/kotlin-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
@@ -10,8 +10,8 @@
             <column name="transaction_id" type="NVARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
-            <column name="lender" type="NVARCHAR"/>
-            <column name="borrower" type="NVARCHAR"/>
+            <column name="lender" type="NVARCHAR(255)"/>
+            <column name="borrower" type="NVARCHAR(255)"/>
             <column name="value" type="INT"/>
             <column name="linear_id" type="VARCHAR(255)"/>
         </createTable>

--- a/kotlin-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
+++ b/kotlin-source/src/main/resources/migration/i-o-u-schema-v1.changelog-init.xml
@@ -1,0 +1,29 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd" >
+    <changeSet author="R3.Corda" id="i-o-u-schema-v1-create-table">
+        <createTable tableName="iou_states">
+            <column name="output_index" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="transaction_id" type="NVARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="lender" type="NVARCHAR"/>
+            <column name="borrower" type="NVARCHAR"/>
+            <column name="value" type="INT"/>
+            <column name="linear_id" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="i-o-u-schema-v1-add-pk">
+        <addPrimaryKey columnNames="output_index, transaction_id" constraintName="iou_states_pkey" tableName="iou_states"/>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="i-o-u-schema-v1-non-clustered-pk" onValidationFail="MARK_RAN">
+        <dropPrimaryKey tableName="iou_states" constraintName="iou_states_pkey"/>
+        <addPrimaryKey tableName="iou_states" columnNames="output_index, transaction_id"
+                       constraintName="iou_states_pkey" clustered="false"/>
+    </changeSet>
+</databaseChangeLog>

--- a/kotlin-source/src/main/resources/migration/i-o-u-schema-v1.changelog-master.xml
+++ b/kotlin-source/src/main/resources/migration/i-o-u-schema-v1.changelog-master.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd" >
+
+    <include file="migration/i-o-u-schema-v1.changelog-init.xml"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
Added Liquibase migration script for databases other than H2.
Default Hibernate mapping changed to uuid-char mapping for UUID field.