### PR TITLE
Flow tests fix

### DIFF
--- a/java-source/src/test/java/com/example/flow/IOUFlowTests.java
+++ b/java-source/src/test/java/com/example/flow/IOUFlowTests.java
@@ -28,7 +28,7 @@ public class IOUFlowTests {
 
     @Before
     public void setup() {
-        network = new MockNetwork(ImmutableList.of("com.example.contract"));
+        network = new MockNetwork(ImmutableList.of("com.example.contract", "com.example.schema"));
         a = network.createPartyNode(null);
         b = network.createPartyNode(null);
         // For real nodes this happens automatically, but we have to manually register the flow for tests.

--- a/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt
+++ b/kotlin-source/src/test/kotlin/com/example/flow/IOUFlowTests.kt
@@ -20,7 +20,7 @@ class IOUFlowTests {
 
     @Before
     fun setup() {
-        network = MockNetwork(listOf("com.example.contract"))
+        network = MockNetwork(listOf("com.example.contract", "com.example.schema"))
         a = network.createPartyNode()
         b = network.createPartyNode()
         // For real nodes this happens automatically, but we have to manually register the flow for tests.


### PR DESCRIPTION
Both java and kotlin flow tests fail with persistence (hibernate) error because IOUState isn't registered with persistence layer. This fix resolves this issue