### PR TITLE
[CORDA-2283] Fix Intellij run configurations

### DIFF
--- a/.idea/runConfigurations/Run_Contract_Tests___Java.xml
+++ b/.idea/runConfigurations/Run_Contract_Tests___Java.xml
@@ -1,28 +1,19 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Contract Tests - Java" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="com.example.java-source.test" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.example.contract.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="java-source_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="com.example.contract" />
     <option name="MAIN_CLASS_NAME" value="com.example.contract.IOUContractTests" />
     <option name="METHOD_NAME" value="" />
-    <option name="TEST_OBJECT" value="class" />
-    <option name="VM_PARAMETERS" value="-ea" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/java-source" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/java-source" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Contract_Tests___Kotlin.xml
+++ b/.idea/runConfigurations/Run_Contract_Tests___Kotlin.xml
@@ -1,28 +1,19 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Contract Tests - Kotlin" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="com.example.kotlin-source.test" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.example.contract.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="kotlin-source_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="com.example.contract" />
     <option name="MAIN_CLASS_NAME" value="com.example.contract.IOUContractTests" />
     <option name="METHOD_NAME" value="" />
-    <option name="TEST_OBJECT" value="class" />
-    <option name="VM_PARAMETERS" value="-ea" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/kotlin-source" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/kotlin-source" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Example_Cordapp___Java.xml
+++ b/.idea/runConfigurations/Run_Example_Cordapp___Java.xml
@@ -1,17 +1,10 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Example Cordapp - Java" type="Application" factoryName="Application" singleton="true">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
     <option name="MAIN_CLASS_NAME" value="com.example.NodeDriver" />
+    <module name="com.example.java-source.test" />
     <option name="VM_PARAMETERS" value="-ea -javaagent:lib/quasar.jar" />
-    <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
-    <option name="ENABLE_SWING_INSPECTOR" value="false" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <module name="java-source_test" />
-    <envs />
-    <method />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Example_Cordapp___Kotlin.xml
+++ b/.idea/runConfigurations/Run_Example_Cordapp___Kotlin.xml
@@ -1,15 +1,15 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Example Cordapp - Kotlin" type="JetRunConfigurationType" factoryName="Kotlin" singleton="true">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
-    <option name="MAIN_CLASS_NAME" value="com.example.NodeDriverKt" />
+    <module name="com.example.kotlin-source.test" />
     <option name="VM_PARAMETERS" value="-ea -javaagent:lib/quasar.jar" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PASS_PARENT_ENVS" value="true" />
-    <module name="kotlin-source_test" />
-    <envs />
-    <method />
+    <option name="MAIN_CLASS_NAME" value="com.example.NodeDriverKt" />
+    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Example_RPC_Client___Java.xml
+++ b/.idea/runConfigurations/Run_Example_RPC_Client___Java.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Run Example RPC Client - Java" type="Application" factoryName="Application" singleton="true">
     <option name="MAIN_CLASS_NAME" value="com.example.client.ExampleClientRPC" />
     <module name="com.example.java-source.test" />
-    <option name="PROGRAM_PARAMETERS" value="localhost:10008" />
+    <option name="PROGRAM_PARAMETERS" value="localhost:10005" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Run_Example_RPC_Client___Java.xml
+++ b/.idea/runConfigurations/Run_Example_RPC_Client___Java.xml
@@ -1,8 +1,10 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Example RPC Client - Java" type="Application" factoryName="Application" singleton="true">
     <option name="MAIN_CLASS_NAME" value="com.example.client.ExampleClientRPC" />
-    <module name="java-source_main" />
+    <module name="com.example.java-source.test" />
     <option name="PROGRAM_PARAMETERS" value="localhost:10008" />
-    <method />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Example_RPC_Client___Kotlin.xml
+++ b/.idea/runConfigurations/Run_Example_RPC_Client___Kotlin.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Run Example RPC Client - Kotlin" type="JetRunConfigurationType" factoryName="Kotlin" singleton="true">
     <module name="com.example.kotlin-source.test" />
     <option name="VM_PARAMETERS" value="" />
-    <option name="PROGRAM_PARAMETERS" value="localhost:10008" />
+    <option name="PROGRAM_PARAMETERS" value="localhost:10005" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PASS_PARENT_ENVS" value="true" />

--- a/.idea/runConfigurations/Run_Example_RPC_Client___Kotlin.xml
+++ b/.idea/runConfigurations/Run_Example_RPC_Client___Kotlin.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Example RPC Client - Kotlin" type="JetRunConfigurationType" factoryName="Kotlin" singleton="true">
-    <module name="kotlin-source_main" />
+    <module name="com.example.kotlin-source.test" />
     <option name="VM_PARAMETERS" value="" />
     <option name="PROGRAM_PARAMETERS" value="localhost:10008" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
@@ -8,6 +8,8 @@
     <option name="PASS_PARENT_ENVS" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.example.client.ExampleClientRPCKt" />
     <option name="WORKING_DIRECTORY" value="" />
-    <method />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Flow_Tests___Java.xml
+++ b/.idea/runConfigurations/Run_Flow_Tests___Java.xml
@@ -1,28 +1,20 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Flow Tests - Java" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="com.example.java-source.test" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.example.flow.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="java-source_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="com.example.flow" />
     <option name="MAIN_CLASS_NAME" value="com.example.flow.IOUFlowTests" />
     <option name="METHOD_NAME" value="" />
-    <option name="TEST_OBJECT" value="class" />
     <option name="VM_PARAMETERS" value="-ea -javaagent:../lib/quasar.jar" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/java-source" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/java-source" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Flow_Tests___Kotlin.xml
+++ b/.idea/runConfigurations/Run_Flow_Tests___Kotlin.xml
@@ -1,28 +1,20 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Flow Tests - Kotlin" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="com.example.kotlin-source.test" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.example.flow.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="kotlin-source_test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="com.example.flow" />
     <option name="MAIN_CLASS_NAME" value="com.example.flow.IOUFlowTests" />
     <option name="METHOD_NAME" value="" />
-    <option name="TEST_OBJECT" value="class" />
     <option name="VM_PARAMETERS" value="-ea -javaagent:../lib/quasar.jar" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/kotlin-source" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/kotlin-source" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Integration_Tests___Java.xml
+++ b/.idea/runConfigurations/Run_Integration_Tests___Java.xml
@@ -1,28 +1,20 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Integration Tests - Java" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="com.example.java-source.integrationTest" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.example.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="java-source_integrationTest" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="com.example" />
     <option name="MAIN_CLASS_NAME" value="com.example.DriverBasedTests" />
     <option name="METHOD_NAME" value="" />
-    <option name="TEST_OBJECT" value="class" />
     <option name="VM_PARAMETERS" value="-ea -javaagent:../lib/quasar.jar" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/java-source" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/java-source" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run_Integration_Tests___Kotlin.xml
+++ b/.idea/runConfigurations/Run_Integration_Tests___Kotlin.xml
@@ -1,28 +1,20 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Integration Tests - Kotlin" type="JUnit" factoryName="JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea">
+    <module name="com.example.kotlin-source.integrationTest" />
+    <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.example.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>
-    <module name="kotlin-source_integrationTest" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="com.example" />
     <option name="MAIN_CLASS_NAME" value="com.example.DriverBasedTests" />
     <option name="METHOD_NAME" value="" />
-    <option name="TEST_OBJECT" value="class" />
     <option name="VM_PARAMETERS" value="-ea -javaagent:../lib/quasar.jar" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/kotlin-source" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/kotlin-source" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/java-source/src/main/java/com/example/state/IOUState.java
+++ b/java-source/src/main/java/com/example/state/IOUState.java
@@ -1,7 +1,9 @@
 package com.example.state;
 
+import com.example.contract.IOUContract;
 import com.example.schema.IOUSchemaV1;
 import com.google.common.collect.ImmutableList;
+import net.corda.core.contracts.BelongsToContract;
 import net.corda.core.contracts.LinearState;
 import net.corda.core.contracts.UniqueIdentifier;
 import net.corda.core.identity.AbstractParty;
@@ -18,6 +20,7 @@ import java.util.List;
  *
  * A state must implement [ContractState] or one of its descendants.
  */
+@BelongsToContract(IOUContract.class)
 public class IOUState implements LinearState, QueryableState {
     private final Integer value;
     private final Party lender;

--- a/java-source/src/test/java/com/example/NodeDriver.java
+++ b/java-source/src/test/java/com/example/NodeDriver.java
@@ -25,15 +25,12 @@ public class NodeDriver {
                     List<CordaFuture<NodeHandle>> nodeFutures = ImmutableList.of(
                             dsl.startNode(new NodeParameters()
                                     .withProvidedName(new CordaX500Name("PartyA", "London", "GB"))
-                                    .withCustomOverrides(ImmutableMap.of("rpcSettings.address", "localhost:10008", "rpcSettings.adminAddress", "localhost:10048", "webAddress", "localhost:10009"))
                                     .withRpcUsers(ImmutableList.of(user))),
                             dsl.startNode(new NodeParameters()
                                     .withProvidedName(new CordaX500Name("PartyB", "New York", "US"))
-                                    .withCustomOverrides(ImmutableMap.of("rpcSettings.address", "localhost:10011", "rpcSettings.adminAddress", "localhost:10051", "webAddress", "localhost:10012"))
                                     .withRpcUsers(ImmutableList.of(user))),
                             dsl.startNode(new NodeParameters()
                                     .withProvidedName(new CordaX500Name("PartyC", "Paris", "FR"))
-                                    .withCustomOverrides(ImmutableMap.of("rpcSettings.address", "localhost:10014", "rpcSettings.adminAddress", "localhost:10054", "webAddress", "localhost:10015"))
                                     .withRpcUsers(ImmutableList.of(user))));
 
                     try {

--- a/kotlin-source/src/test/kotlin/com/example/NodeDriver.kt
+++ b/kotlin-source/src/test/kotlin/com/example/NodeDriver.kt
@@ -14,18 +14,15 @@ fun main(args: Array<String>) {
     val user = User("user1", "test", permissions = setOf("ALL"))
     driver(DriverParameters(waitForAllNodesToFinish = true)) {
         val nodeFutures = listOf(
-                startNode(
-                        providedName = CordaX500Name("PartyA", "London", "GB"),
-                        customOverrides = mapOf("rpcSettings.address" to "localhost:10008", "rpcSettings.adminAddress" to "localhost:10048", "webAddress" to "localhost:10009"),
-                        rpcUsers = listOf(user)),
-                startNode(
-                        providedName = CordaX500Name("PartyB", "New York", "US"),
-                        customOverrides = mapOf("rpcSettings.address" to "localhost:10011", "rpcSettings.adminAddress" to "localhost:10051", "webAddress" to "localhost:10012"),
-                        rpcUsers = listOf(user)),
-                startNode(
-                        providedName = CordaX500Name("PartyC", "Paris", "FR"),
-                        customOverrides = mapOf("rpcSettings.address" to "localhost:10014", "rpcSettings.adminAddress" to "localhost:10054", "webAddress" to "localhost:10015"),
-                        rpcUsers = listOf(user)))
+            startNode(
+                    providedName = CordaX500Name("PartyA", "London", "GB"),
+                    rpcUsers = listOf(user)),
+            startNode(
+                    providedName = CordaX500Name("PartyB", "New York", "US"),
+                    rpcUsers = listOf(user)),
+            startNode(
+                    providedName = CordaX500Name("PartyC", "Paris", "FR"),
+                    rpcUsers = listOf(user)))
 
         val (nodeA, nodeB, nodeC) = nodeFutures.map { it.getOrThrow() }
 


### PR DESCRIPTION
The IntelliJ run configurations didn't work and this PR fixes them. All tests can now be executed from the IDE and the configurations don't complain about missing module anymore. 

`Run Example Cordapp` no longer fails due to `Uknown property 'webAddress'`.  The `customOverrides` are removed to prevent wrong port allocation.